### PR TITLE
Add EngineKind dispatch, CLI restructure, and post-review refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +76,9 @@ name = "art-engine-cli"
 version = "0.1.0"
 dependencies = [
  "art-engine-core",
+ "art-engine-engines",
+ "clap",
+ "serde_json",
 ]
 
 [[package]]
@@ -40,6 +99,18 @@ name = "art-engine-dla"
 version = "0.1.0"
 dependencies = [
  "art-engine-core",
+]
+
+[[package]]
+name = "art-engine-engines"
+version = "0.1.0"
+dependencies = [
+ "art-engine-core",
+ "art-engine-gray-scott",
+ "image",
+ "proptest",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -129,10 +200,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -155,6 +293,25 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -239,6 +396,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +419,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -297,6 +473,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "noise"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +517,25 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -367,6 +582,15 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -539,6 +763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slotmap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +776,12 @@ checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -608,6 +844,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/core",
+    "crates/engines",
     "crates/wasm",
     "crates/cli",
     "crates/gray-scott",
@@ -15,6 +16,7 @@ members = [
 ]
 default-members = [
     "crates/core",
+    "crates/engines",
     "crates/cli",
     "crates/gray-scott",
     "crates/physarum",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,3 +6,6 @@ description = "CLI binary for the art-engine"
 
 [dependencies]
 art-engine-core = { path = "../core" }
+art-engine-engines = { path = "../engines" }
+clap = { version = "4", features = ["derive"] }
+serde_json = "1"

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,0 +1,114 @@
+//! Structured CLI errors with meaningful exit codes.
+//!
+//! Exit code scheme:
+//! - 0:  success
+//! - 2:  clap arg parse error (automatic, before our code runs)
+//! - 10: engine error (unknown engine, step failure, bad dimensions)
+//! - 11: I/O error (file write, snapshot)
+//! - 12: input error (bad palette, bad JSON params)
+//! - 13: serialization error
+
+use art_engine_core::EngineError;
+use std::fmt;
+
+/// Errors produced by CLI operations, each mapped to a distinct exit code.
+pub enum CliError {
+    /// An engine-level error (unknown engine, step failure, bad dimensions).
+    Engine(EngineError),
+    /// An I/O error (file write, snapshot rendering).
+    Io(String),
+    /// A user input error (bad palette name, bad JSON params).
+    Input(String),
+    /// A serialization error (JSON output failure).
+    Serialization(String),
+}
+
+impl CliError {
+    /// Returns the process exit code for this error.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            CliError::Engine(_) => 10,
+            CliError::Io(_) => 11,
+            CliError::Input(_) => 12,
+            CliError::Serialization(_) => 13,
+        }
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CliError::Engine(e) => write!(f, "{e}"),
+            CliError::Io(msg) => write!(f, "{msg}"),
+            CliError::Input(msg) => write!(f, "{msg}"),
+            CliError::Serialization(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl From<EngineError> for CliError {
+    fn from(e: EngineError) -> Self {
+        match e {
+            EngineError::Io(msg) => CliError::Io(msg),
+            other => CliError::Engine(other),
+        }
+    }
+}
+
+impl From<serde_json::Error> for CliError {
+    fn from(e: serde_json::Error) -> Self {
+        CliError::Serialization(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_error_exit_code_is_10() {
+        let err = CliError::Engine(EngineError::UnknownEngine("foo".into()));
+        assert_eq!(err.exit_code(), 10);
+    }
+
+    #[test]
+    fn io_error_exit_code_is_11() {
+        let err = CliError::Io("write failed".into());
+        assert_eq!(err.exit_code(), 11);
+    }
+
+    #[test]
+    fn input_error_exit_code_is_12() {
+        let err = CliError::Input("bad palette".into());
+        assert_eq!(err.exit_code(), 12);
+    }
+
+    #[test]
+    fn serialization_error_exit_code_is_13() {
+        let err = CliError::Serialization("json fail".into());
+        assert_eq!(err.exit_code(), 13);
+    }
+
+    #[test]
+    fn from_engine_error_io_routes_to_cli_io() {
+        let engine_err = EngineError::Io("disk full".into());
+        let cli_err = CliError::from(engine_err);
+        assert_eq!(cli_err.exit_code(), 11);
+        assert!(cli_err.to_string().contains("disk full"));
+    }
+
+    #[test]
+    fn from_engine_error_non_io_routes_to_cli_engine() {
+        let engine_err = EngineError::UnknownEngine("xyz".into());
+        let cli_err = CliError::from(engine_err);
+        assert_eq!(cli_err.exit_code(), 10);
+        assert!(cli_err.to_string().contains("xyz"));
+    }
+
+    #[test]
+    fn from_serde_json_error_routes_to_serialization() {
+        let bad_json = serde_json::from_str::<serde_json::Value>("{invalid");
+        let cli_err = CliError::from(bad_json.unwrap_err());
+        assert_eq!(cli_err.exit_code(), 13);
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,143 @@
 #![deny(unsafe_code)]
 //! CLI binary for the art-engine generative art system.
+//!
+//! Subcommands:
+//! - `render <engine>` — run an engine N steps, write PNG
+//! - `list` — print available engines and palettes
+
+mod error;
+
+use art_engine_core::{Engine, Palette};
+use art_engine_engines::EngineKind;
+use clap::{Parser, Subcommand};
+use error::CliError;
+use std::path::PathBuf;
+use std::process;
+
+#[derive(Parser)]
+#[command(name = "art-engine", about = "Generative art engine CLI")]
+struct Cli {
+    /// Output as JSON instead of human-readable text.
+    #[arg(long, global = true)]
+    json: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run an engine for N steps and write a PNG snapshot.
+    Render {
+        /// Engine name (e.g. "gray-scott").
+        engine: String,
+
+        /// Canvas width in pixels.
+        #[arg(short = 'W', long, default_value_t = 256)]
+        width: usize,
+
+        /// Canvas height in pixels.
+        #[arg(short = 'H', long, default_value_t = 256)]
+        height: usize,
+
+        /// Number of simulation steps.
+        #[arg(short, long, default_value_t = 1000)]
+        steps: usize,
+
+        /// PRNG seed for deterministic output.
+        #[arg(long, default_value_t = 42)]
+        seed: u64,
+
+        /// Palette name (ocean, neon, earth, monochrome, vapor, fire).
+        #[arg(short, long, default_value = "ocean")]
+        palette: String,
+
+        /// Output file path.
+        #[arg(short, long, default_value = "output.png")]
+        output: PathBuf,
+
+        /// Engine parameters as a JSON string.
+        #[arg(long, default_value = "{}")]
+        params: String,
+    },
+    /// List available engines and palettes.
+    List,
+}
+
+fn run(cli: Cli) -> Result<(), CliError> {
+    match cli.command {
+        Command::List => {
+            let engines = EngineKind::list_engines();
+            let palettes = Palette::list_names();
+            if cli.json {
+                let info = serde_json::json!({
+                    "engines": engines,
+                    "palettes": palettes,
+                });
+                println!("{}", serde_json::to_string_pretty(&info)?);
+            } else {
+                println!("Engines:");
+                for name in engines {
+                    println!("  {name}");
+                }
+                println!("Palettes:");
+                println!("  {}", palettes.join(", "));
+            }
+        }
+        Command::Render {
+            engine,
+            width,
+            height,
+            steps,
+            seed,
+            palette,
+            output,
+            params,
+        } => {
+            let params: serde_json::Value = serde_json::from_str(&params)
+                .map_err(|e| CliError::Input(format!("invalid --params JSON: {e}")))?;
+
+            let palette =
+                Palette::from_name(&palette).map_err(|e| CliError::Input(e.to_string()))?;
+
+            let mut eng = EngineKind::from_name(&engine, width, height, seed, &params)?;
+
+            (0..steps).try_for_each(|_| eng.step())?;
+
+            art_engine_engines::snapshot::write_png(eng.field(), &palette, &output)?;
+
+            if cli.json {
+                let info = serde_json::json!({
+                    "engine": engine,
+                    "width": width,
+                    "height": height,
+                    "steps": steps,
+                    "seed": seed,
+                    "output": output.display().to_string(),
+                });
+                println!("{}", serde_json::to_string_pretty(&info)?);
+            } else {
+                eprintln!(
+                    "rendered {engine} ({width}x{height}, {steps} steps, seed {seed}) -> {}",
+                    output.display()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
 
 fn main() {
-    println!("art-engine CLI");
+    let cli = Cli::parse();
+    let json_mode = cli.json;
+    if let Err(e) = run(cli) {
+        if json_mode {
+            let j = serde_json::json!({"error": e.to_string(), "exit_code": e.exit_code()});
+            eprintln!("{}", serde_json::to_string_pretty(&j).unwrap_or_default());
+        } else {
+            eprintln!("error: {e}");
+        }
+        process::exit(e.exit_code());
+    }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -54,6 +54,18 @@ pub enum EngineError {
     /// A layer with the given name already exists in the canvas.
     #[error("duplicate layer name: {0}")]
     DuplicateLayerName(String),
+
+    /// An engine name was not recognized.
+    #[error("unknown engine: {0}")]
+    UnknownEngine(String),
+
+    /// A palette name was not recognized.
+    #[error("unknown palette: {0}")]
+    UnknownPalette(String),
+
+    /// An I/O or external library error.
+    #[error("I/O error: {0}")]
+    Io(String),
 }
 
 #[cfg(test)]
@@ -153,6 +165,36 @@ mod tests {
         assert!(
             msg.contains("particles"),
             "expected message containing 'particles', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_engine_includes_name() {
+        let err = EngineError::UnknownEngine("foobar".into());
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("foobar"),
+            "expected message containing 'foobar', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_palette_includes_name() {
+        let err = EngineError::UnknownPalette("rainbow".into());
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("rainbow"),
+            "expected message containing 'rainbow', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn io_error_includes_message() {
+        let err = EngineError::Io("file not found".into());
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("file not found"),
+            "expected message containing 'file not found', got: {msg}"
         );
     }
 

--- a/crates/core/src/palette.rs
+++ b/crates/core/src/palette.rs
@@ -7,6 +7,9 @@
 use crate::color::{oklch_to_srgb, srgb_to_oklch, OkLch, Srgb};
 use crate::error::EngineError;
 
+/// All built-in palette names, kept in sync with `from_name`.
+const BUILTIN_PALETTE_NAMES: &[&str] = &["ocean", "neon", "earth", "monochrome", "vapor", "fire"];
+
 /// A palette of colors stored in OKLCh, sampled by interpolation.
 ///
 /// Colors are evenly spaced along the `t` parameter: `sample(0.0)` returns
@@ -220,6 +223,28 @@ impl Palette {
     pub fn fire() -> Self {
         Self::from_hex(&["#800000", "#cc0000", "#ff4500", "#ff8c00", "#ffd700"])
             .expect("fire palette hex values are valid")
+    }
+
+    // -- Registry --
+
+    /// Returns a slice of all built-in palette names.
+    pub fn list_names() -> &'static [&'static str] {
+        BUILTIN_PALETTE_NAMES
+    }
+
+    /// Constructs a built-in palette by name.
+    ///
+    /// Returns `EngineError::UnknownPalette` if the name is not recognized.
+    pub fn from_name(name: &str) -> Result<Self, EngineError> {
+        match name {
+            "ocean" => Ok(Self::ocean()),
+            "neon" => Ok(Self::neon()),
+            "earth" => Ok(Self::earth()),
+            "monochrome" => Ok(Self::monochrome()),
+            "vapor" => Ok(Self::vapor()),
+            "fire" => Ok(Self::fire()),
+            _ => Err(EngineError::UnknownPalette(name.to_string())),
+        }
     }
 }
 
@@ -604,6 +629,32 @@ mod tests {
         assert!(srgb.r >= 0.0 && srgb.r <= 1.0, "r out of range: {}", srgb.r);
         assert!(srgb.g >= 0.0 && srgb.g <= 1.0, "g out of range: {}", srgb.g);
         assert!(srgb.b >= 0.0 && srgb.b <= 1.0, "b out of range: {}", srgb.b);
+    }
+
+    // -- Registry tests --
+
+    #[test]
+    fn list_names_returns_expected_count() {
+        assert_eq!(Palette::list_names().len(), 6);
+    }
+
+    #[test]
+    fn from_name_succeeds_for_all_listed_names() {
+        for name in Palette::list_names() {
+            assert!(
+                Palette::from_name(name).is_ok(),
+                "from_name failed for listed palette: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_name_returns_error_for_unknown() {
+        let result = Palette::from_name("rainbow");
+        assert!(matches!(
+            result,
+            Err(EngineError::UnknownPalette(ref n)) if n == "rainbow"
+        ));
     }
 
     // -- Built-in palette tests --

--- a/crates/engines/Cargo.toml
+++ b/crates/engines/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "art-engine-engines"
+version = "0.1.0"
+edition = "2021"
+description = "Engine registry and CPU snapshot for the art-engine"
+
+[features]
+default = ["png"]
+png = ["dep:image"]
+
+[dependencies]
+art-engine-core = { path = "../core" }
+art-engine-gray-scott = { path = "../gray-scott" }
+serde_json = "1"
+image = { version = "0.25", default-features = false, features = ["png"], optional = true }
+
+[dev-dependencies]
+proptest = "1"
+tempfile = "3"

--- a/crates/engines/src/lib.rs
+++ b/crates/engines/src/lib.rs
@@ -1,0 +1,156 @@
+#![deny(unsafe_code)]
+//! Engine registry: maps engine names to implementations and provides CPU-side
+//! snapshot rendering.
+//!
+//! This crate sits between `art-engine-core` (which defines the `Engine` trait)
+//! and the individual engine crates (`art-engine-gray-scott`, etc.). Both the
+//! CLI and WASM bindings depend on this crate to avoid duplicating dispatch logic.
+
+pub mod pixel;
+
+#[cfg(feature = "png")]
+pub mod snapshot;
+
+use art_engine_core::error::EngineError;
+use art_engine_core::field::Field;
+use art_engine_core::Engine;
+use serde_json::Value;
+
+/// All available engine names.
+const ENGINE_NAMES: &[&str] = &["gray-scott"];
+
+/// Enumeration of all available generative art engines.
+///
+/// Wraps each engine implementation and delegates `Engine` trait methods.
+/// Use [`EngineKind::from_name`] for string-based construction (CLI, WASM).
+pub enum EngineKind {
+    /// Gray-Scott reaction-diffusion.
+    GrayScott(art_engine_gray_scott::GrayScott),
+}
+
+impl EngineKind {
+    /// Constructs an engine by name.
+    ///
+    /// Returns `EngineError::UnknownEngine` if the name is not recognized.
+    pub fn from_name(
+        name: &str,
+        width: usize,
+        height: usize,
+        seed: u64,
+        params: &Value,
+    ) -> Result<Self, EngineError> {
+        match name {
+            "gray-scott" => Ok(EngineKind::GrayScott(
+                art_engine_gray_scott::GrayScott::from_json(width, height, seed, params)?,
+            )),
+            _ => Err(EngineError::UnknownEngine(name.to_string())),
+        }
+    }
+
+    /// Returns a slice of all recognized engine names.
+    pub fn list_engines() -> &'static [&'static str] {
+        ENGINE_NAMES
+    }
+}
+
+impl Engine for EngineKind {
+    fn step(&mut self) -> Result<(), EngineError> {
+        match self {
+            EngineKind::GrayScott(e) => e.step(),
+        }
+    }
+
+    fn field(&self) -> &Field {
+        match self {
+            EngineKind::GrayScott(e) => e.field(),
+        }
+    }
+
+    fn params(&self) -> Value {
+        match self {
+            EngineKind::GrayScott(e) => e.params(),
+        }
+    }
+
+    fn param_schema(&self) -> Value {
+        match self {
+            EngineKind::GrayScott(e) => e.param_schema(),
+        }
+    }
+
+    fn hue_field(&self) -> Option<&Field> {
+        match self {
+            EngineKind::GrayScott(e) => e.hue_field(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn from_name_gray_scott_succeeds() {
+        let engine = EngineKind::from_name("gray-scott", 32, 32, 42, &json!({}));
+        assert!(engine.is_ok());
+    }
+
+    #[test]
+    fn from_name_unknown_returns_error() {
+        let result = EngineKind::from_name("nonexistent", 32, 32, 42, &json!({}));
+        assert!(matches!(result, Err(EngineError::UnknownEngine(_))));
+    }
+
+    #[test]
+    fn list_engines_includes_gray_scott() {
+        let names = EngineKind::list_engines();
+        assert!(names.contains(&"gray-scott"));
+    }
+
+    #[test]
+    fn trait_delegation_step_and_field() {
+        let mut engine = EngineKind::from_name("gray-scott", 16, 16, 42, &json!({})).unwrap();
+        assert_eq!(engine.field().width(), 16);
+        assert_eq!(engine.field().height(), 16);
+        engine.step().unwrap();
+    }
+
+    #[test]
+    fn trait_delegation_params_and_schema() {
+        let engine = EngineKind::from_name("gray-scott", 16, 16, 42, &json!({})).unwrap();
+        let params = engine.params();
+        assert!(params.get("feed_rate").is_some());
+        let schema = engine.param_schema();
+        assert!(schema.get("feed_rate").is_some());
+    }
+
+    #[test]
+    fn trait_delegation_hue_field() {
+        let engine = EngineKind::from_name("gray-scott", 16, 16, 42, &json!({})).unwrap();
+        assert!(engine.hue_field().is_none());
+    }
+
+    #[test]
+    fn determinism_same_seed() {
+        let mut a = EngineKind::from_name("gray-scott", 32, 32, 99, &json!({})).unwrap();
+        let mut b = EngineKind::from_name("gray-scott", 32, 32, 99, &json!({})).unwrap();
+        for _ in 0..10 {
+            a.step().unwrap();
+            b.step().unwrap();
+        }
+        assert!(a
+            .field()
+            .data()
+            .iter()
+            .zip(b.field().data().iter())
+            .all(|(va, vb)| va.to_bits() == vb.to_bits()));
+    }
+
+    #[test]
+    fn object_safety() {
+        let engine = EngineKind::from_name("gray-scott", 16, 16, 42, &json!({})).unwrap();
+        let boxed: Box<dyn Engine> = Box::new(engine);
+        assert_eq!(boxed.field().width(), 16);
+    }
+}

--- a/crates/engines/src/pixel.rs
+++ b/crates/engines/src/pixel.rs
@@ -1,0 +1,73 @@
+//! Pure-computation pixel buffer conversion from [`Field`] + [`Palette`].
+//!
+//! This module is always available (no feature gate) so that both the `png`
+//! snapshot path and the WASM `ImageData` path can share the same conversion.
+
+use art_engine_core::field::Field;
+use art_engine_core::palette::Palette;
+
+/// Maps field values through a palette to produce an RGBA8 pixel buffer.
+///
+/// Each field value `t` in [0, 1] is sampled from the palette and written as
+/// four bytes (R, G, B, 255). The buffer length is `width * height * 4`.
+pub fn field_to_rgba(field: &Field, palette: &Palette) -> Vec<u8> {
+    field
+        .data()
+        .iter()
+        .flat_map(|&t| {
+            let srgb = palette.sample(t);
+            let r = (srgb.r * 255.0).round() as u8;
+            let g = (srgb.g * 255.0).round() as u8;
+            let b = (srgb.b * 255.0).round() as u8;
+            [r, g, b, 255u8]
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use art_engine_core::field::Field;
+    use art_engine_core::palette::Palette;
+
+    #[test]
+    fn field_to_rgba_correct_length() {
+        let field = Field::new(8, 4).unwrap();
+        let palette = Palette::ocean();
+        let buf = field_to_rgba(&field, &palette);
+        assert_eq!(buf.len(), 8 * 4 * 4);
+    }
+
+    #[test]
+    fn field_to_rgba_alpha_always_255() {
+        let field = Field::filled(4, 4, 0.5).unwrap();
+        let palette = Palette::neon();
+        let buf = field_to_rgba(&field, &palette);
+        for (i, &byte) in buf.iter().enumerate() {
+            if i % 4 == 3 {
+                assert_eq!(byte, 255, "alpha at pixel {} should be 255", i / 4);
+            }
+        }
+    }
+
+    #[test]
+    fn field_to_rgba_boundary_colors() {
+        // t=0 should give first palette color, t=1 should give last
+        let palette = Palette::monochrome(); // black -> white
+        let field_zero = Field::filled(1, 1, 0.0).unwrap();
+        let field_one = Field::filled(1, 1, 1.0).unwrap();
+
+        let buf_zero = field_to_rgba(&field_zero, &palette);
+        let buf_one = field_to_rgba(&field_one, &palette);
+
+        // First color of monochrome is #000000 -> near 0
+        assert!(buf_zero[0] < 10, "r at t=0: {}", buf_zero[0]);
+        assert!(buf_zero[1] < 10, "g at t=0: {}", buf_zero[1]);
+        assert!(buf_zero[2] < 10, "b at t=0: {}", buf_zero[2]);
+
+        // Last color of monochrome is #ffffff -> near 255
+        assert!(buf_one[0] > 245, "r at t=1: {}", buf_one[0]);
+        assert!(buf_one[1] > 245, "g at t=1: {}", buf_one[1]);
+        assert!(buf_one[2] > 245, "b at t=1: {}", buf_one[2]);
+    }
+}

--- a/crates/engines/src/snapshot.rs
+++ b/crates/engines/src/snapshot.rs
@@ -1,0 +1,47 @@
+//! CPU-side PNG rendering of a [`Field`].
+//!
+//! This module is feature-gated behind `png` (default on) so that WASM builds
+//! can depend on the `engines` crate without pulling in the `image` crate.
+//! The pixel buffer conversion itself lives in [`crate::pixel`] (always available).
+
+use art_engine_core::error::EngineError;
+use art_engine_core::field::Field;
+use art_engine_core::palette::Palette;
+use std::path::Path;
+
+use crate::pixel::field_to_rgba;
+
+/// Writes a field as a PNG image, mapping values through the given palette.
+///
+/// Returns `EngineError::InvalidDimensions` if the field dimensions overflow
+/// `u32`, or `EngineError::Io` on write failure.
+pub fn write_png(field: &Field, palette: &Palette, path: &Path) -> Result<(), EngineError> {
+    let rgba = field_to_rgba(field, palette);
+    let w = u32::try_from(field.width()).map_err(|_| EngineError::InvalidDimensions)?;
+    let h = u32::try_from(field.height()).map_err(|_| EngineError::InvalidDimensions)?;
+    let img = image::RgbaImage::from_raw(w, h, rgba)
+        .ok_or_else(|| EngineError::Io("RGBA buffer size mismatch".into()))?;
+    img.save(path).map_err(|e| EngineError::Io(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use art_engine_core::field::Field;
+    use art_engine_core::palette::Palette;
+
+    #[test]
+    fn write_png_round_trip() {
+        let field = Field::filled(16, 16, 0.3).unwrap();
+        let palette = Palette::ocean();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.png");
+
+        write_png(&field, &palette, &path).unwrap();
+
+        // Verify the file exists and can be read back
+        let img = image::open(&path).unwrap().to_rgba8();
+        assert_eq!(img.width(), 16);
+        assert_eq!(img.height(), 16);
+    }
+}


### PR DESCRIPTION
## Summary

- **Engines crate** (`crates/engines/`): `EngineKind` enum wrapping Gray-Scott with `from_name()`/`list_engines()` dispatch, CPU snapshot PNG rendering, and `pixel` module for RGBA buffer conversion
- **Post-review refactors**: `EngineError` gains `UnknownPalette` and `Io` variants; `Palette::from_name()`/`list_names()` centralizes palette registry; `field_to_rgba` split into ungated `pixel` module for WASM reuse; `write_png` returns `EngineError` instead of leaking `image::ImageError`; `expect()` replaced with `?` propagation
- **CLI restructure**: `CliError` enum with typed exit codes (10=engine, 11=I/O, 12=input, 13=serialization); JSON error output on stderr in `--json` mode; `list` shows both engines and palettes; `try_for_each` for step loop

Fixes #46, fixes #45

## Test plan

- [x] `bash xtask.sh check` — all green (fmt, clippy, test, doc, wasm)
- [x] `cargo run -p art-engine-cli -- render gray-scott -o test.png` — exit 0
- [x] `cargo run -p art-engine-cli -- render unknown` — exit 10
- [x] `cargo run -p art-engine-cli -- render gray-scott --palette rainbow` — exit 12
- [x] `cargo run -p art-engine-cli -- render gray-scott --palette rainbow --json` — exit 12, JSON on stderr
- [x] `cargo run -p art-engine-cli -- list` — engines + palettes
- [x] `cargo run -p art-engine-cli -- list --json` — `{"engines":[...],"palettes":[...]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)